### PR TITLE
fix: gckn link redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Layton Bot
 
-Layton Bot is a multipurpose moderation bot developed for [the discord server](https://discord.gg/2xuWVbUEFA) of [getCodingKnowledge](https://github.com/getCodingKnowledge).
+Layton Bot is a multipurpose moderation bot developed for [the discord server](https://discord.gg/2xuWVbUEFA) of [getCodingKnowledge](https://www.youtube.com/c/getCodingKnowledge).
 
 - [Discord.js](https://discord.js.org/) - The main library used to interface with discord
 - [Discord-Akairo](https://discord-akairo.github.io/) - The framework the bot is built on


### PR DESCRIPTION
Update redirection to the YouTube channel and not to the GitHub Org