### PR TITLE
Amélioration des autocomplete

### DIFF
--- a/commands/utils/faq.js
+++ b/commands/utils/faq.js
@@ -173,7 +173,7 @@ module.exports = {
     const focusedOption = interaction.options.getFocused(true);
     const choices = guildSettings.faq?.map(tag => tag.name);
     if(!choices) return;
-    const filtered = choices.filter(choice => choice.startsWith(focusedOption.value.toLowerCase()));
+    const filtered = choices.filter(choice => choice.includes(focusedOption.value.toLowerCase()));
     const filteredLimit = filtered.slice(0, 15);
     await interaction.respond(filteredLimit.map(choice => ({ name: choice, value: choice })));
   }

--- a/commands/utils/help.js
+++ b/commands/utils/help.js
@@ -20,6 +20,7 @@ module.exports = {
       description: "Taper le nom de votre commande",
       type: "STRING",
       required: false,
+      autocomplete:true
     },
   ],
   async runInteraction(client, interaction) {
@@ -79,4 +80,12 @@ Ne pas inclure ces caractères -> {}, [] et <> dans vos commandes.
       ephemeral: true,
     });
   },
+  async runAutocomplete(client, interaction) {
+    const focusedOption = interaction.options.getFocused(true);
+    const choices = client.commands?.map(cmd => cmd.name);
+    if(!choices) return;
+    const filtered = choices.filter(choice => choice.includes(focusedOption.value.toLowerCase()));
+    const filteredLimit = filtered.slice(0, 15);
+    await interaction.respond(filteredLimit.map(choice => ({ name: choice, value: choice })));
+  }
 };


### PR DESCRIPTION
## Amélioration des autocomplete sur 2 commandes du bot

- Help: Ajout des autocomplete pour le nom de la commande (optionnel) 
- Faq: Utilisation de la méthode includes à la place de startsWith pour mieux cibler les termes clés

**Action**
- Closes : https://github.com/abyo/layton-bot/issues/23
