### PR TITLE
Fix(Command): Djsdoc

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -56,7 +56,7 @@ const djsdocs = [
   {
     name: "Voice/stable",
     url: "https://raw.githubusercontent.com/discordjs/docs/main/voice/stable.json",
-    github: "https://github.com/discordjs/discord.js/tree/stable/",
+    github: "https://github.com/discordjs/voice/tree/stable/",
     branch: "stable",
     doc: "https://discord.js.org/#/docs/voice/stable/",
     data: "",

--- a/constants.js
+++ b/constants.js
@@ -38,7 +38,7 @@ const djsdocs = [
   {
     name: "Builders/stable",
     url: "https://raw.githubusercontent.com/discordjs/docs/main/builders/stable.json",
-    github: "https://github.com/discordjs/discord.js/tree/stable/",
+    github: "https://github.com/discordjs/builders/tree/stable/src/",
     branch: "stable",
     doc: "https://discord.js.org/#/docs/builders/stable/",
     data: "",

--- a/constants.js
+++ b/constants.js
@@ -20,7 +20,7 @@ const djsdocs = [
   {
     name: "Collection/stable",
     url: "https://raw.githubusercontent.com/discordjs/docs/main/collection/stable.json",
-    github: "https://github.com/discordjs/discord.js/tree/stable/",
+    github: "https://github.com/discordjs/collection/tree/stable/",
     branch: "stable",
     doc: "https://discord.js.org/#/docs/collection/stable/",
     data: "",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dayjs": "1.10.7",
     "discord.js": "13.6.0",
     "dotenv": "16.0.0",
-    "ghom-djs-docs": "^2.0.1",
     "glob": "7.2.0",
     "mongoose": "6.2.3",
     "ms": "2.1.3",

--- a/utils/djsdoc/embeds.js
+++ b/utils/djsdoc/embeds.js
@@ -42,7 +42,7 @@ function buildGeneralEmbed(parent, meta) {
   if (parent.meta) description += `\n\n[Source code](${meta.github + parent.meta.path + "/" + parent.meta.file + "#L" + parent.meta.line})`;
   description = normalizeStr(description);
   const embed = new MessageEmbed()
-    .setAuthor({ name: parent.name, url: `${meta.doc}${parent.type}/${parent.name}`, iconURL: "https://cdn.discordapp.com/attachments/871732319449395240/959924116046090250/ezgif-5-73b32bedb6.png" })
+    .setAuthor({ name: meta.name + " - " +parent.name, url: `${meta.doc}${parent.type}/${parent.name}`, iconURL: "https://cdn.discordapp.com/attachments/871732319449395240/959924116046090250/ezgif-5-73b32bedb6.png" })
     .setDescription(description)
     .setColor(0x00AE86);
   return embed;
@@ -71,7 +71,7 @@ function buildSpecificEmbed(parent, child, meta) {
   description = normalizeStr(description);
   const embed = new MessageEmbed()
     //.setTitle(child.async ? `[async] ${parent.name + "#" + child.name}` : parent.name + "#" + child.name)
-    .setAuthor({ name: child.async ? `[async] ${parent.name + "#" + child.name}` : parent.name + "#" + child.name, url: `${meta.doc}${parent.type}/${parent.name}?scrollTo=${child.name}`, iconURL: "https://cdn.discordapp.com/attachments/871732319449395240/959924116046090250/ezgif-5-73b32bedb6.png" })
+    .setAuthor({ name: child.async ? `${meta.name + " - " + "[async] " +parent.name + "#" + child.name}` : meta.name + " - " + parent.name + "#" + child.name, url: `${meta.doc}${parent.type}/${parent.name}?scrollTo=${child.name}`, iconURL: "https://cdn.discordapp.com/attachments/871732319449395240/959924116046090250/ezgif-5-73b32bedb6.png" })
     .setColor(0x00AE86)
     .setDescription(description);
   return embed;


### PR DESCRIPTION
- Correction des liens vers les repos github des branches stables (les repos ne sont pas encore migrée vers discordjs/discord.js dans la branche stable).
- Ajout du nom de la doc et de la branche pour permettre d'identifier de quelle documentation et branche il s'agit
- Supression du module ghom-djs-docs qui n'est pas utilisé