### PR TITLE
Allow line-break in faq/show command

### DIFF
--- a/commands/utils/faq.js
+++ b/commands/utils/faq.js
@@ -170,7 +170,7 @@ module.exports = {
       if(!guildSettings.faq) return interaction.reply("Il n'y a pas de tags.");
       const faq = guildSettings.faq.find(faq => faq.name === name);
       if(!faq) return interaction.reply("Ce tag n'existe pas.");
-      interaction.reply(`${member}, tu es probablement concerné par cette réponse:\n${faq.content}`);
+      interaction.reply(`${member}, tu es probablement concerné par cette réponse:\n${faq.content.replaceAll("\\n ", "\n").replaceAll("\\n", "\n")}`);
       break;
     }
     case "list":{


### PR DESCRIPTION
**Allow line break in faq show command***

This PR allow line break in show command to allow clean formatting.
We need tow replaceAll because discord (currently) not support multi lines text inputs in slash-commands and sometime a space is added.